### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI build
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   run:


### PR DESCRIPTION
Potential fix for [https://github.com/FeaDeaD/facebook-php-business-sdk-up/security/code-scanning/1](https://github.com/FeaDeaD/facebook-php-business-sdk-up/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a typical CI workflow that only checks out code and runs tests, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The best way is to add the following at the top level of the workflow file, just after the `name` and `on` keys:

```yaml
permissions:
  contents: read
```

This ensures that all jobs in the workflow only have read access to repository contents, adhering to the principle of least privilege. No other changes are needed unless a job requires additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
